### PR TITLE
Allow building with persistent-2.11

### DIFF
--- a/src/Pantry/Storage.hs
+++ b/src/Pantry/Storage.hs
@@ -16,6 +16,8 @@
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TupleSections #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleInstances #-}
 module Pantry.Storage
   ( SqlBackend
   , initStorage


### PR DESCRIPTION
Attempting to build `pantry-0.5.1.3` with `persistent-2.11` yields the following build error:

```
[10 of 19] Compiling Pantry.Storage   ( src/Pantry/Storage.hs, dist/build/Pantry/Storage.o, dist/build/Pantry/Storage.dyn_o )

src/Pantry/Storage.hs:124:1: error:
    Generating Persistent entities now requires the following language extensions:

DataKinds
FlexibleInstances

Please enable the extensions by copy/pasting these lines into the top of your file:

{-# LANGUAGE DataKinds #-}
{-# LANGUAGE FlexibleInstances #-}
    |
124 | share [mkPersist sqlSettings, mkMigrate "migrateAll"] [persistLowerCase|
    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^...
```

This patch adopts the advice from the error message.